### PR TITLE
Unbuffered output for seeing the progress of an ansible run

### DIFF
--- a/lib/vagrant-guest_ansible/guest_script.sh
+++ b/lib/vagrant-guest_ansible/guest_script.sh
@@ -33,8 +33,9 @@ if [ ! -z "$ANSIBLE_EXTRA_VARS" -a "$ANSIBLE_EXTRA_VARS" != " " ]; then
         ANSIBLE_EXTRA_VARS=" --extra-vars \"$ANSIBLE_EXTRA_VARS\""
 fi
 
-# stream output and show colors
+# stream output
 export PYTHONUNBUFFERED=1
+# show ANSI-colored output
 export ANSIBLE_FORCE_COLOR=true
 
 cd ${ANSIBLE_DIR}


### PR DESCRIPTION
Previously the whole ansible run was buffered. It would run for e.g. 15 minutes and you would see nothing until the run completed or failed.

By setting `PYTHONUNBUFFERED=1` the output will be flushed immediately (or at least more often) so you can see the progress of the ansible run.

Also added `ANSIBLE_FORCE_COLOR=true` to get the green (stdout) / red (stderr) colored output as configured in provisioner.rb
