### PR TITLE
Fix NoMethodError - there is no `String#blank?`method

### DIFF
--- a/lib/vagrant-guest_ansible/provisioner.rb
+++ b/lib/vagrant-guest_ansible/provisioner.rb
@@ -14,7 +14,7 @@ module VagrantPlugins
           './ansible',
           config.playbook,
           File.basename(self.setup_inventory_file),
-          (config.extra_vars.blank? ? "''" : config.extra_vars.map { |k,v| "#{k}=#{v}" }.join(" "))
+          format_extra_vars(config.extra_vars)
         ].join(' ')
         
         command = "chmod +x #{config.upload_path} && #{config.upload_path} #{args}"
@@ -53,6 +53,15 @@ module VagrantPlugins
       end
 
       protected
+
+      # converts the extra_vars to a properly formatted string
+      def format_extra_vars(extra_vars)
+        if extra_vars.kind_of?(String)
+          extra_vars.strip
+        elsif extra_vars.kind_of?(Hash)
+          extra_vars.map { |k,v| "#{k}=#{v}" }.join(" ")
+        end
+      end
 
       # This method yields the path to a script to upload and execute
       # on the remote server. This method will properly clean up the


### PR DESCRIPTION
When the provisioner is started via `vagrant provision` (or `vagrant up` respectively) it will bail out early with a `NoMethodError`, e.g. like this:

```
Y:\workspace\vagrant-ansible-example>vagrant provision
==> default: Configuring cache buckets...
==> default: Running provisioner: guest_ansible...
Y:/home/.vagrant.d/gems/gems/vagrant-guest_ansible-0.0.1/lib/vagrant-guest_ansible/provisioner.rb:17:in `provision': undefined method `blank?' for nil:NilClass (NoMethodError)
        from Y:/tools/vagrant-1.6.5/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/builtin/provision.rb:127:in `run_provisioner'
        from Y:/tools/vagrant-1.6.5/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:95:in `call'
        from Y:/tools/vagrant-1.6.5/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:95:in `block in finalize_action'
        from Y:/tools/vagrant-1.6.5/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
        from Y:/tools/vagrant-1.6.5/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
        from Y:/tools/vagrant-1.6.5/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/builder.rb:116:in `call'
        from Y:/tools/vagrant-1.6.5/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/runner.rb:66:in `block in run'
        from Y:/tools/vagrant-1.6.5/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/util/busy.rb:19:in `busy'
...
```

It uses the `String#blank?` method which is only available in Rails afaik.

This PR extracts the formatting logic into a separate method and uses `strip` rather than `blank?` to ensure that the args are properly formatted
