### PR TITLE
Allow inventory_path to point to a subdirectory and copy its content.

### DIFF
--- a/lib/vagrant-guest_ansible/guest_script.sh
+++ b/lib/vagrant-guest_ansible/guest_script.sh
@@ -10,7 +10,7 @@ if [ ! -f /vagrant/$ANSIBLE_PLAYBOOK ]; then
         exit 1
 fi
 
-if [ ! -f /vagrant/$ANSIBLE_HOSTS ]; then
+if [ ! -e /vagrant/$ANSIBLE_HOSTS ]; then
         echo "ERROR: Cannot find the given Ansible hosts file."
         exit 2
 fi
@@ -47,7 +47,7 @@ export PYTHONUNBUFFERED=1
 # show ANSI-colored output
 export ANSIBLE_FORCE_COLOR=true
 
-cp /vagrant/${ANSIBLE_HOSTS} ${TEMP_HOSTS} && chmod -x ${TEMP_HOSTS}
+cp -R /vagrant/${ANSIBLE_HOSTS} ${TEMP_HOSTS} && find ${TEMP_HOSTS} -type f -exec chmod -x {} \; 
 echo "Running Ansible as $USER:"
 ansible-playbook /vagrant/${ANSIBLE_PLAYBOOK} --inventory-file=${TEMP_HOSTS} --connection=local $ANSIBLE_EXTRA_VARS
-rm ${TEMP_HOSTS}
+rm -R ${TEMP_HOSTS}

--- a/lib/vagrant-guest_ansible/provisioner.rb
+++ b/lib/vagrant-guest_ansible/provisioner.rb
@@ -10,7 +10,7 @@ module VagrantPlugins
 
         args = [
           config.playbook,
-          File.basename(self.setup_inventory_file),
+          self.setup_inventory_file,
           format_extra_vars(config.extra_vars)
         ].join(' ')
 


### PR DESCRIPTION
This is necesarry in a team where other members are using mac/linux where the default inventory location is .vagrant/provisioners/ansible/inventory/
And because it allows to use a group_vars subfolder.
