### PR TITLE
Adding ability to pip install Ansible at specific git url

### DIFF
--- a/lib/vagrant-guest_ansible/config.rb
+++ b/lib/vagrant-guest_ansible/config.rb
@@ -5,6 +5,7 @@ module VagrantPlugins
     class Config < Vagrant.plugin("2", :config)
       attr_accessor :playbook
       attr_accessor :extra_vars
+      attr_accessor :ansible_git_url
       attr_accessor :inventory_path
       attr_accessor :ask_sudo_pass
       attr_accessor :limit
@@ -23,6 +24,7 @@ module VagrantPlugins
       def initialize
         @playbook = UNSET_VALUE
         @extra_vars = UNSET_VALUE
+        @ansible_git_url = UNSET_VALUE
         @inventory_path = UNSET_VALUE
         @ask_sudo_pass = UNSET_VALUE
         @limit = UNSET_VALUE
@@ -56,6 +58,7 @@ module VagrantPlugins
       def finalize!
         @playbook = nil if @playbook == UNSET_VALUE
         @extra_vars = nil if @extra_vars == UNSET_VALUE
+        @ansible_git_url = nil if @ansible_git_url == UNSET_VALUE
         @inventory_path = nil if @inventory_path == UNSET_VALUE
         @ask_sudo_pass = nil if @ask_sudo_pass == UNSET_VALUE
         @limit = nil if @limit == UNSET_VALUE

--- a/lib/vagrant-guest_ansible/guest_script.sh
+++ b/lib/vagrant-guest_ansible/guest_script.sh
@@ -3,6 +3,7 @@
 ANSIBLE_PLAYBOOK=$1
 ANSIBLE_HOSTS=$2
 ANSIBLE_EXTRA_VARS="$3"
+ANSIBLE_GIT_URL="$4"
 TEMP_HOSTS="/tmp/ansible_hosts"
 
 if [ ! -f /vagrant/$ANSIBLE_PLAYBOOK ]; then
@@ -35,7 +36,13 @@ if ! command -v ansible >/dev/null; then
         sudo pip install setuptools --no-use-wheel --upgrade
         echo "Installing required python modules."
         sudo pip install paramiko pyyaml jinja2 markupsafe
-        sudo pip install ansible
+
+        echo "Installing Ansible."
+        if [ ! -z "$ANSIBLE_GIT_URL" ]; then
+          sudo pip install -U -e git+${ANSIBLE_GIT_URL}#egg=ansible
+        else
+          sudo pip install ansible
+        fi
 fi
 
 if [ ! -z "$ANSIBLE_EXTRA_VARS" -a "$ANSIBLE_EXTRA_VARS" != " " ]; then

--- a/lib/vagrant-guest_ansible/provisioner.rb
+++ b/lib/vagrant-guest_ansible/provisioner.rb
@@ -12,9 +12,13 @@ module VagrantPlugins
           config.playbook,
           File.basename(self.setup_inventory_file),
           format_extra_vars(config.extra_vars)
-        ].join(' ')
+        ]
 
-        command = "chmod +x #{config.upload_path} && #{config.upload_path} #{args}"
+        if !config.ansible_git_url.nil?
+          args << config.ansible_git_url
+        end
+
+        command = "chmod +x #{config.upload_path} && #{config.upload_path} #{args.join(' ')}"
 
         with_script_file do |path|
 


### PR DESCRIPTION
This is useful if you need to install Ansible at a specific git url including branch/tag.

Personally, I needed to pip install the latest stable-1.9 branch of Ansible into my machine to pick up a specific change which hadn't made its way into a released version yet.

Just set ansible_git_url config param in your Vagrantfile for example:

```
  provisioner = Vagrant::Util::Platform.windows? ? :guest_ansible : :ansible

  config.vm.provision provisioner do |ansible|
    ansible.playbook = "ansible/devbox.yml"
    if provisioner == :guest_ansible
      ansible.ansible_git_url = "https://github.com/ansible/ansible.git@stable-1.9"
    end
   ...
  end
```
