### PR TITLE
Fixes vovimayhem/vagrant-guest_ansible#13 by adding missing dependencies

### DIFF
--- a/lib/vagrant-guest_ansible/guest_script.sh
+++ b/lib/vagrant-guest_ansible/guest_script.sh
@@ -18,11 +18,11 @@ fi
 if ! command -v ansible >/dev/null; then
         echo "Installing Ansible dependencies and Git."
         if command -v yum >/dev/null; then
-                sudo yum install -y gcc git python python-devel
+                sudo yum install -y gcc git python python-devel libffi-dev libssl-dev
         elif command -v apt-get >/dev/null; then
                 sudo apt-get update -qq
                 #sudo apt-get install -y -qq git python-yaml python-paramiko python-jinja2
-                sudo apt-get install -y -qq git python python-dev
+                sudo apt-get install -y -qq git python python-dev libffi-dev libssl-dev
         else
                 echo "neither yum nor apt-get found!"
                 exit 1


### PR DESCRIPTION
Additional dependencies added are libffi-dev and libssl-dev. Adding these fixed the issue and was able to provision using ansible on a windows host.
